### PR TITLE
docnow daemons

### DIFF
--- a/roles/docnow_role/handlers/main.yml
+++ b/roles/docnow_role/handlers/main.yml
@@ -1,2 +1,14 @@
 ---
 # handlers file for docnow_role
+
+- name: restart url-fetcher
+  service:
+    name: url-fetcher
+    state: restarted
+    enabled: yes
+
+- name: restart stream-loader
+  service:
+    name: stream-loader
+    state: restarted
+    enabled: yes

--- a/roles/docnow_role/tasks/main.yml
+++ b/roles/docnow_role/tasks/main.yml
@@ -68,6 +68,26 @@
   become: true
   become_user: "{{ docnow_user }}"
 
+- name: Docnow | stream-loader configuration
+  template:
+    src: stream-loader.service.j2
+    dest: "/etc/systemd/system/stream-loader.service"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart stream-loader
+
+- name: Docnow | url-fetcher configuration
+  template:
+    src: url-fetcher.service.j2
+    dest: "/etc/systemd/system/url-fetcher.service"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart url-fetcher
+
 - name: Docnow | migrate and createdb
   command: npm run migrate
   args:

--- a/roles/docnow_role/templates/stream-loader.service.j2
+++ b/roles/docnow_role/templates/stream-loader.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=DocNow Stream Loader
+
+[Service]
+User={{ docnow_user }}
+WorkingDirectory={{ docnow_app_root }}
+ExecStart=npm run stream-loader
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/docnow_role/templates/url-fetcher.service.j2
+++ b/roles/docnow_role/templates/url-fetcher.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=DocNow Stream Loader
+
+[Service]
+User={{ docnow_user }}
+WorkingDirectory={{ docnow_app_root }}
+ExecStart=npm run url-fetcher
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds two systemd processes url-fetcher and stream-loader to run as services when the docnow app is running. When running in development they are handled inline in the webserver. But in production they should run as independent services so that loading of tweets and fetching metadata about urls don't negatively impact the resposiveness of the web application.

I'm not 100% I did this right @kayiwa I haven't used molecule before but I tried running `ROLE=docnow_role python run_molecule.py` and it caught some linting problems. It did seem to throw an error about a missing variable `docnow_version` which seemed unrelated to the changes I was making?

```
TASK [docnow_role : Docnow | Clone Docnow appraisal app] ***********************
fatal: [docnow-instance]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'docnow_version' is undefined\n\nThe error appears to be in '/home/ed/Projects/docnow-ansible/roles/docnow_role/tasks/main.yml': line 8, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Docnow | Clone Docnow appraisal app\n  ^ here\n"}
```