### PR TITLE
Restart url-fetcher & tweet-loader

### DIFF
--- a/roles/docnow_role/templates/tweet-loader.service.j2
+++ b/roles/docnow_role/templates/tweet-loader.service.j2
@@ -5,6 +5,7 @@ Description=DocNow Tweet Loader
 User={{ docnow_user }}
 WorkingDirectory={{ docnow_app_root }}
 ExecStart=/usr/bin/npm run tweet-loader
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/docnow_role/templates/url-fetcher.service.j2
+++ b/roles/docnow_role/templates/url-fetcher.service.j2
@@ -5,6 +5,7 @@ Description=DocNow Stream Loader
 User={{ docnow_user }}
 WorkingDirectory={{ docnow_app_root }}
 ExecStart=/usr/bin/npm run url-fetcher
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
These daemons need to run for the docnow application to be able to collect tweets and display information about webpages referenced in tweets. This commit modifies the systemd config so that they are restarted if they exit for any reason.

I think this is a quick fix for https://github.com/DocNow/docnow/issues/173