### PR TITLE
add newer version of redis

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 # tasks file for redis
+- name: Add nginx stable repository from PPA and install its signing key on Debian target
+  ansible.builtin.apt_repository:
+    repo: "ppa:redislabs/redis"
+    update_cache: true
+
 - name: install redis
   package:
     name: "{{ redis_packages }}"

--- a/roles/redis/vars/main.yml
+++ b/roles/redis/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for redis
-redis_packages: "redis-server"
+redis_packages: "redis"
 redis_configuration_directory: "/etc/redis"
 redis_configuration_file: "redis.conf"
 redis_owner: "redis"


### PR DESCRIPTION
use redislabs/ppa instead of ubuntu upstream.
change the package name to match redislabs

this will close #61
